### PR TITLE
Feature/add sort by alphabet method

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add `countriex` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:countriex, "~> 1.0.1", github: "normancapule/countriex"}]
+  [{:countriex, "~> 1.0.2", github: "normancapule/countriex"}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Countriex
 
 [![Build Status](https://travis-ci.org/navinpeiris/countriex.svg?branch=master)](https://travis-ci.org/navinpeiris/countriex)
-[![Hex version](https://img.shields.io/hexpm/v/countriex.svg "Hex version")](https://hex.pm/packages/countriex)
-[![Hex downloads](https://img.shields.io/hexpm/dt/countriex.svg "Hex downloads")](https://hex.pm/packages/countriex)
+[![Hex version](https://img.shields.io/hexpm/v/countriex.svg 'Hex version')](https://hex.pm/packages/countriex)
+[![Hex downloads](https://img.shields.io/hexpm/dt/countriex.svg 'Hex downloads')](https://hex.pm/packages/countriex)
 [![Deps Status](https://beta.hexfaktor.org/badge/all/github/navinpeiris/countriex.svg)](https://beta.hexfaktor.org/github/navinpeiris/countriex)
 [![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
 
@@ -24,6 +24,12 @@ To get all country information:
 
 ```elixir
 Countriex.all
+```
+
+To get all countries sorted alphabetically:
+
+```elixir
+Countriex.all_sort_by_alphabet
 ```
 
 To get all state information:

--- a/lib/countriex.ex
+++ b/lib/countriex.ex
@@ -11,6 +11,11 @@ defmodule Countriex do
   def all, do: Data.countries
 
   @doc """
+  Returns all country data sorted by its name
+  """
+  def all_sort_by_alphabet, do: Enum.sort_by(all(), fn(c) -> c.name end)
+
+  @doc """
   Returns the first matching country with the given criteria, or `nil` if a country with that data does not exist.
 
   ## Examples

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Countriex.Mixfile do
   def project do
     [
       app: :countriex,
-      version: "1.0.1",
+      version: "1.0.2",
       name: "Countriex",
       description: "All sorts of useful information about every country. A pure elixir port of the ruby Countries gem",
       elixir: "~> 1.3",

--- a/test/countriex_test.exs
+++ b/test/countriex_test.exs
@@ -10,6 +10,14 @@ defmodule CountriexTest do
     end
   end
 
+  describe "all_sort_by_alphabet/0" do
+    test "returns all countries sorted alphabetically" do
+      countries = Countriex.all_sort_by_alphabet
+
+      assert List.first(countries).name == "Afghanistan"
+    end
+  end
+
   describe "get_by/2" do
     test "returns the first country to match the given criteria" do
       country = Countriex.get_by(:name, "Jamaica")


### PR DESCRIPTION
## Changes

- Add method to get all countries arranged alphabetically by name
- Update Readme to include new method

## Usage

    countries = Countriex.all_sort_by_alphabet